### PR TITLE
Translate - Fixed docs and feedback spacing

### DIFF
--- a/src/app/components/header/queue/queue.component.html
+++ b/src/app/components/header/queue/queue.component.html
@@ -15,19 +15,21 @@
     <mat-progress-bar class="global-progress" mode="determinate" value="{{ dlQueueProgress }}"></mat-progress-bar>
   </div>
 
-  <div class="feedback-div header-link">
-    <a href="javascript:feedback.showForm();" onfocus="this.blur()"> <mat-icon>comment</mat-icon> {{ 'FEEDBACK' | translate }}</a>
-  </div>
+  <div class="doc-feedback-div">
+    <div class="docs-div header-link">
+      <app-docs-modal class="text-link"
+                      text="Docs"
+                      url="https://docs.asf.alaska.edu/vertex/manual/#downloads-queue">
+      </app-docs-modal>
+    </div>
 
-  <div class="docs-div header-link">
-    <app-docs-modal class="text-link"
-                    text="Docs"
-                    url="https://docs.asf.alaska.edu/vertex/manual/#downloads-queue">
-    </app-docs-modal>
+    <div class="feedback-div header-link">
+      <a href="javascript:feedback.showForm();" onfocus="this.blur()"> <mat-icon>comment</mat-icon> {{ 'FEEDBACK' | translate }}</a>
+    </div>
   </div>
 
   <div class="dl-close-x" (click)="onCloseDownloadQueue()">
-    <mat-icon></mat-icon>
+    <mat-icon>close</mat-icon>
   </div>
 
 </div>

--- a/src/app/components/header/queue/queue.component.scss
+++ b/src/app/components/header/queue/queue.component.scss
@@ -106,15 +106,6 @@ $idk-pad: 21px;
   overflow: hidden;
 }
 
-.feedback-div {
-  position: absolute;
-  top: 42px;
-  right: 16px;
-  text-align: right;
-  float: right;
-  cursor: pointer;
-}
-
 .feedback-link {
   font-size: 18px;
 
@@ -247,13 +238,23 @@ button {
   left: -10px;
 }
 
+.doc-feedback-div {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: -42px;
+  margin-right: 20px;
+}
+
 .docs-div {
-  position: absolute;
-  top: 42px;
-  right: 130px;
-  text-align: right;
-  float: right;
   cursor: pointer;
+  flex: 0 1 auto;
+  margin-right: 20px;
+  margin-top: 2px;
+}
+
+.feedback-div {
+  cursor: pointer;
+  flex: 0 1 auto;
 }
 
 .header-link {


### PR DESCRIPTION
The download queue had wrong spacing when the language changed for "Docs" and "Feedback" in the top header of the dialog.